### PR TITLE
Added backwards compatibility for older Value & Api-Client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ before_script:
 
 install:
   - composer config github-oauth.github.com ${GITHUB_TOKEN}
-  - composer install -n --dev
   - composer require "digipolisgent/api-client:${API_CLIENT_VERSION}" --no-update
   - composer require "digipolisgent/value:${VALUE_VERSION}" --no-update
+  - composer install -n --dev
 
 script:
   - vendor/bin/grumphp run

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: php
+
 php:
   - 7.2
   - 7.3
+
+env:
+  - API_CLIENT_VERSION=^1.1
+    VALUE_VERSION=^1.1
+  - API_CLIENT_VERSION=^2.0
+    VALUE_VERSION=^2.0
 
 sudo: false
 
@@ -13,6 +20,8 @@ before_script:
 install:
   - composer config github-oauth.github.com ${GITHUB_TOKEN}
   - composer install -n --dev
+  - composer require "digipolisgent/api-client:${API_CLIENT_VERSION}" --no-update
+  - composer require "digipolisgent/value:${VALUE_VERSION}" --no-update
 
 script:
   - vendor/bin/grumphp run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All Notable changes to `digipolisgent/flanders-basicregisters` package.
 
+## [Unreleased]
+
+### Added
+
+* Added backwards compatibility for older Value & Api-Client packages.
+  This to avoid dependency issues when combined with other packages.
+
 ## [0.1.0]
 
 Initial release of the Flanders Basic Registers client package.

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     ],
     "require": {
         "php": ">=7.2",
-        "digipolisgent/api-client": "^2.0.0",
-        "digipolisgent/value": "^2.0.0",
+        "digipolisgent/api-client": "^1.1|^2.0",
+        "digipolisgent/value": "^1.1|^2.0",
         "ext-json": "*"
     },
     "require-dev": {

--- a/src/Request/AbstractJsonRequest.php
+++ b/src/Request/AbstractJsonRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigipolisGent\Flanders\BasicRegisters\Request;
+
+use DigipolisGent\API\Client\Request\AcceptType;
+use DigipolisGent\API\Client\Request\MethodType;
+use DigipolisGent\API\Client\Uri\UriInterface;
+use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Abstract request.
+ */
+abstract class AbstractJsonRequest extends Request implements RequestInterface
+{
+    /**
+     * Constructor.
+     *
+     * @param \DigipolisGent\API\Client\Uri\UriInterface $uri
+     *   The URI for the request object.
+     */
+    public function __construct(UriInterface $uri)
+    {
+        parent::__construct(
+            MethodType::GET,
+            $uri->getUri(),
+            ['Accept' => AcceptType::JSON]
+        );
+    }
+}

--- a/src/Request/AddressDetailRequest.php
+++ b/src/Request/AddressDetailRequest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DigipolisGent\Flanders\BasicRegisters\Request;
 
-use DigipolisGent\API\Client\Request\AbstractJsonRequest;
 use DigipolisGent\Flanders\BasicRegisters\Uri\AddressDetailUri;
 use DigipolisGent\Flanders\BasicRegisters\Value\Address\AddressId;
 

--- a/src/Request/AddressListRequest.php
+++ b/src/Request/AddressListRequest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DigipolisGent\Flanders\BasicRegisters\Request;
 
-use DigipolisGent\API\Client\Request\AbstractJsonRequest;
 use DigipolisGent\Flanders\BasicRegisters\Filter\FiltersInterface;
 use DigipolisGent\Flanders\BasicRegisters\Pager\PagerInterface;
 use DigipolisGent\Flanders\BasicRegisters\Uri\AddressListUri;

--- a/src/Request/AddressMatchRequest.php
+++ b/src/Request/AddressMatchRequest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DigipolisGent\Flanders\BasicRegisters\Request;
 
-use DigipolisGent\API\Client\Request\AbstractJsonRequest;
 use DigipolisGent\Flanders\BasicRegisters\Filter\FiltersInterface;
 use DigipolisGent\Flanders\BasicRegisters\Uri\AddressMatchUri;
 

--- a/src/Request/MunicipalityNameDetailRequest.php
+++ b/src/Request/MunicipalityNameDetailRequest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DigipolisGent\Flanders\BasicRegisters\Request;
 
-use DigipolisGent\API\Client\Request\AbstractJsonRequest;
 use DigipolisGent\Flanders\BasicRegisters\Uri\MunicipalityNameDetailUri;
 use DigipolisGent\Flanders\BasicRegisters\Value\Municipality\MunicipalityNameId;
 

--- a/src/Request/MunicipalityNameListRequest.php
+++ b/src/Request/MunicipalityNameListRequest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DigipolisGent\Flanders\BasicRegisters\Request;
 
-use DigipolisGent\API\Client\Request\AbstractJsonRequest;
 use DigipolisGent\Flanders\BasicRegisters\Pager\PagerInterface;
 use DigipolisGent\Flanders\BasicRegisters\Uri\MunicipalityNameListUri;
 

--- a/src/Request/PostInfoDetailRequest.php
+++ b/src/Request/PostInfoDetailRequest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DigipolisGent\Flanders\BasicRegisters\Request;
 
-use DigipolisGent\API\Client\Request\AbstractJsonRequest;
 use DigipolisGent\Flanders\BasicRegisters\Uri\PostInfoDetailUri;
 use DigipolisGent\Flanders\BasicRegisters\Value\Post\PostInfoId;
 

--- a/src/Request/PostInfoListRequest.php
+++ b/src/Request/PostInfoListRequest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DigipolisGent\Flanders\BasicRegisters\Request;
 
-use DigipolisGent\API\Client\Request\AbstractJsonRequest;
 use DigipolisGent\Flanders\BasicRegisters\Filter\FiltersInterface;
 use DigipolisGent\Flanders\BasicRegisters\Pager\PagerInterface;
 use DigipolisGent\Flanders\BasicRegisters\Uri\PostInfoListUri;

--- a/src/Request/StreetNameDetailRequest.php
+++ b/src/Request/StreetNameDetailRequest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DigipolisGent\Flanders\BasicRegisters\Request;
 
-use DigipolisGent\API\Client\Request\AbstractJsonRequest;
 use DigipolisGent\Flanders\BasicRegisters\Uri\StreetNameDetailUri;
 use DigipolisGent\Flanders\BasicRegisters\Value\Street\StreetNameId;
 

--- a/src/Request/StreetNameListRequest.php
+++ b/src/Request/StreetNameListRequest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace DigipolisGent\Flanders\BasicRegisters\Request;
 
-use DigipolisGent\API\Client\Request\AbstractJsonRequest;
-use DigipolisGent\Flanders\BasicRegisters\Filter\Filters;
 use DigipolisGent\Flanders\BasicRegisters\Filter\FiltersInterface;
 use DigipolisGent\Flanders\BasicRegisters\Pager\PagerInterface;
 use DigipolisGent\Flanders\BasicRegisters\Uri\StreetNameListUri;

--- a/tests/Request/AbstractJsonRequestTest.php
+++ b/tests/Request/AbstractJsonRequestTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigipolisGent\Tests\Flanders\BasicRegisters\Request;
+
+use DigipolisGent\API\Client\Request\AcceptType;
+use DigipolisGent\API\Client\Request\MethodType;
+use DigipolisGent\Flanders\BasicRegisters\Request\AddressDetailRequest;
+use DigipolisGent\Flanders\BasicRegisters\Value\Address\AddressId;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \DigipolisGent\Flanders\BasicRegisters\Request\AbstractJsonRequest
+ */
+class AbstractJsonRequestTest extends TestCase
+{
+    /**
+     * The method and accept headers are set.
+     *
+     * @test
+     */
+    public function methodAndHeadersAreSetDuringConstruction(): void
+    {
+        $addressId = new AddressId(789456);
+        $request = new AddressDetailRequest($addressId);
+
+        $this->assertEquals(MethodType::GET, $request->getMethod());
+        $this->assertEquals([AcceptType::JSON], $request->getHeader('Accept'));
+    }
+}


### PR DESCRIPTION
## Description

Added support for:

* digipolisgent/api-client : v1.x and 2.x
* digipolisgent/value : 1.x and 2.x

## Motivation and Context

Add support to install the package in projects where there are dependencies on older versions of the api-client & value packages.
