### PR TITLE
Changed extending interfaces to the BasicRegisterInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All Notable changes to `digipolisgent/flanders-basicregisters` package.
 
+## [Unreleased]
+
+### Changed
+
+* Changed extending the interface by the BasicRegisterInterface instead of the
+  BasicRegister class.
+
 ## [0.2.0]
 
 ### Added

--- a/src/BasicRegister.php
+++ b/src/BasicRegister.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace DigipolisGent\Flanders\BasicRegisters;
 
-use DigipolisGent\API\Cache\CacheableInterface;
 use DigipolisGent\API\Cache\CacheableTrait;
 use DigipolisGent\API\Client\ClientInterface;
-use DigipolisGent\API\Logger\LoggableInterface;
 use DigipolisGent\API\Logger\LoggableTrait;
 use DigipolisGent\API\Service\ServiceInterface;
 use DigipolisGent\Flanders\BasicRegisters\Service\AddressService;
@@ -22,7 +20,7 @@ use DigipolisGent\Flanders\BasicRegisters\Service\StreetNameServiceInterface;
 /**
  * Container of all BasicRegister services.
  */
-class BasicRegister implements BasicRegisterInterface, CacheableInterface, LoggableInterface
+class BasicRegister implements BasicRegisterInterface
 {
     use CacheableTrait;
     use LoggableTrait;

--- a/src/BasicRegisterInterface.php
+++ b/src/BasicRegisterInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DigipolisGent\Flanders\BasicRegisters;
 
+use DigipolisGent\API\Cache\CacheableInterface;
+use DigipolisGent\API\Logger\LoggableInterface;
 use DigipolisGent\Flanders\BasicRegisters\Service\AddressServiceInterface;
 use DigipolisGent\Flanders\BasicRegisters\Service\MunicipalityNameServiceInterface;
 use DigipolisGent\Flanders\BasicRegisters\Service\PostInfoServiceInterface;
@@ -12,7 +14,7 @@ use DigipolisGent\Flanders\BasicRegisters\Service\StreetNameServiceInterface;
 /**
  * Container of all BasicRegister services.
  */
-interface BasicRegisterInterface
+interface BasicRegisterInterface extends CacheableInterface, LoggableInterface
 {
     /**
      * Get the address(es) related service.


### PR DESCRIPTION
Fixed dependency hierarchy.

## Description

The BasicRegisterInterface should extend from Cacheable & Loggable interface instead of the implenting BasicRegister class.

## Motivation and Context

Better dependency hierarchy and easier to test.

## How Has This Been Tested?

Unit Tests.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing 
  functionality to change).

