### PR TITLE
Added method to PostInfoNames to get all names at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All Notable changes to `digipolisgent/flanders-basicregisters` package.
 
+## Unreleased
+
+### Added
+
+* Added method to PostInfoNames to get all names at once.
+  The post info names object contains all PostInfoName objects at once
+  including the main name and sub-municipality names. There are use cases
+  where an array of all names, starting with the main name, are required.
+
+### Changed
+
+* The main name is written in all caps. That name is now transformed into
+  Capitalized Words.
+
 ## [0.2.1]
 
 ### Changed

--- a/src/Value/Post/PostInfoNames.php
+++ b/src/Value/Post/PostInfoNames.php
@@ -58,7 +58,7 @@ class PostInfoNames extends CollectionAbstract
     }
 
     /**
-     * Get all the names as array of string.
+     * Get all the names as array of strings.
      *
      * The main name will be the first in the list.
      *

--- a/src/Value/Post/PostInfoNames.php
+++ b/src/Value/Post/PostInfoNames.php
@@ -58,6 +58,27 @@ class PostInfoNames extends CollectionAbstract
     }
 
     /**
+     * Get all the names as array of string.
+     *
+     * The main name will be the first in the list.
+     *
+     * @return string[]
+     */
+    public function names(): array
+    {
+        $names = [$this->name()];
+        foreach ($this->values as $value) {
+            if ($value->sameValueAs($this->geographicalName())) {
+                continue;
+            }
+
+            $names[] = $value->spelling();
+        }
+
+        return $names;
+    }
+
+    /**
      * Has the names collection submunicipality names.
      *
      * This will be true if there are more then 1 name in the collection.
@@ -83,16 +104,25 @@ class PostInfoNames extends CollectionAbstract
      * The main name is:
      * - The name written in all caps.
      * - If no all caps name, the first one from the collection.
+     *
+     * If the main name is found:
+     * - The value is replaced by a Capitalized version of the name.
      */
     private function detectMainName(): void
     {
-        foreach ($this->values as $geographicalName) {
+        foreach ($this->values as $key => $geographicalName) {
             /** @var \DigipolisGent\Flanders\BasicRegisters\Value\Geographical\GeographicalName $geographicalName */
             if (preg_match('/[a-z]/', $geographicalName->spelling())) {
                 continue;
             }
 
-            $this->mainName = $geographicalName;
+            $name = new GeographicalName(
+                $geographicalName->languageCode(),
+                ucwords(strtolower($geographicalName->spelling()), '-')
+            );
+
+            $this->mainName = $name;
+            $this->values[$key] = $name;
             return;
         }
 

--- a/tests/Value/Post/PostInfoNamesTest.php
+++ b/tests/Value/Post/PostInfoNamesTest.php
@@ -41,6 +41,8 @@ class PostInfoNamesTest extends TestCase
     /**
      * Main name is the first one written in all caps.
      *
+     * The name will be transformed to Capitalized Words.
+     *
      * @test
      */
     public function mainNameIsFirstItemInAllCaps(): void
@@ -53,12 +55,32 @@ class PostInfoNamesTest extends TestCase
         );
 
         $this->assertEquals(
-            $this->createGeographicalName('BAR-TEST'),
+            $this->createGeographicalName('Bar-Test'),
             $postInfoNames->geographicalName()
         );
         $this->assertEquals(
-            'BAR-TEST',
+            'Bar-Test',
             $postInfoNames->name()
+        );
+    }
+
+    /**
+     * Names array contains all names with main name first.
+     *
+     * @test
+     */
+    public function namesArrayHasMainNameFirst(): void
+    {
+        $postInfoNames = new PostInfoNames(
+            $this->createGeographicalName('Foo'),
+            $this->createGeographicalName('BAR-TEST'),
+            $this->createGeographicalName('Biz'),
+            $this->createGeographicalName('Baz')
+        );
+
+        $this->assertEquals(
+            ['Bar-Test', 'Foo', 'Biz', 'Baz'],
+            $postInfoNames->names()
         );
     }
 
@@ -81,7 +103,7 @@ class PostInfoNamesTest extends TestCase
      *
      * @test
      */
-    public function hasSubMunicipalitiesIfThereIsMoteThanOneName(): void
+    public function hasSubMunicipalitiesIfThereIsMoreThanOneName(): void
     {
         $postInfoNames = new PostInfoNames(
             $this->createGeographicalName('Foo'),
@@ -106,7 +128,7 @@ class PostInfoNamesTest extends TestCase
         );
 
         $this->assertEquals(
-            'BAR-TEST',
+            'Bar-Test',
             (string) $postInfoNames
         );
     }


### PR DESCRIPTION
Add a uniform way to get all names of a postal info object.

## Description

The post info names object contains all PostInfoName objects at once
including the main name and sub-municipality names. There are use cases
where an array of all names, starting with the main name, are required.

The main name is written in all caps. That name is now transformed into
Capitalized Words.

## Types of changes

- [x] New feature (non-breaking change which adds functionality).