### PR TITLE
Fixed including empty filters in the query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All Notable changes to `digipolisgent/flanders-basicregisters` package.
 
+## [Unreleased]
+
+### Fixed
+
+* Fixed including empty filters in the query string.
+  When a filter was added with a NULL value, then the filter key was not added
+  to the query string.
+
 ## [0.2.2]
 
 ### Added

--- a/examples/111-AddressMatch.php
+++ b/examples/111-AddressMatch.php
@@ -7,6 +7,7 @@
 use DigipolisGent\Flanders\BasicRegisters\BasicRegister;
 use DigipolisGent\Flanders\BasicRegisters\Client\Client;
 use DigipolisGent\Flanders\BasicRegisters\Configuration\Configuration;
+use DigipolisGent\Flanders\BasicRegisters\Filter\BusNumberFilter;
 use DigipolisGent\Flanders\BasicRegisters\Filter\Filters;
 use DigipolisGent\Flanders\BasicRegisters\Filter\HouseNumberFilter;
 use DigipolisGent\Flanders\BasicRegisters\Filter\MunicipalityNameFilter;
@@ -34,8 +35,9 @@ printStep('Create the filters.');
 $filters = new Filters(
     new MunicipalityNameFilter('gent'),
     new PostalCodeFilter(9000),
-    new StreetNameFilter('bellevue'),
-    new HouseNumberFilter(5)
+    new StreetNameFilter('Ter Platen'),
+    new HouseNumberFilter(64),
+    new BusNumberFilter('')
 );
 
 printStep('List of address that match the search.');

--- a/src/Cache/CacheKey.php
+++ b/src/Cache/CacheKey.php
@@ -41,6 +41,7 @@ final class CacheKey
      */
     public static function fromId(AbstractId $identifier): CacheKey
     {
+        $matches = [];
         $className = get_class($identifier);
         preg_match('#\\\\(\w+)$#', $className, $matches);
 

--- a/src/Filter/Filters.php
+++ b/src/Filter/Filters.php
@@ -33,7 +33,7 @@ final class Filters implements FiltersInterface
     {
         $filters = [];
         foreach ($this->filters as $filter) {
-            $filters[$filter->name()] = $filter->value();
+            $filters[$filter->name()] = (string) $filter->value();
         }
 
         return $filters;

--- a/tests/Filter/FiltersTest.php
+++ b/tests/Filter/FiltersTest.php
@@ -33,6 +33,25 @@ class FiltersTest extends TestCase
     }
 
     /**
+     * NULL values are casted to empty strings.
+     *
+     * @test
+     */
+    public function filterValuesAreCastedToString(): void
+    {
+        $filters = new Filters(
+            $this->createFilterMock('Biz', ''),
+            $this->createFilterMock('Baz', null)
+        );
+
+        $expected = [
+            'Biz' => '',
+            'Baz' => '',
+        ];
+        $this->assertSame($expected, $filters->filters());
+    }
+
+    /**
      * Create filter mock.
      *
      * @param string $name

--- a/tests/Uri/AbstractUriWithQueryTest.php
+++ b/tests/Uri/AbstractUriWithQueryTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigipolisGent\Tests\Flanders\BasicRegisters\Uri;
+
+use DigipolisGent\Flanders\BasicRegisters\Filter\FiltersInterface;
+use DigipolisGent\Flanders\BasicRegisters\Pager\PagerInterface;
+use DigipolisGent\Flanders\BasicRegisters\Uri\AddressListUri;
+use PHPStan\Testing\TestCase;
+
+/**
+ * @covers \DigipolisGent\Flanders\BasicRegisters\Uri\AbstractUriWithQuery
+ */
+class AbstractUriWithQueryTest extends TestCase
+{
+    /**
+     * URI without filters.
+     *
+     * @test
+     */
+    public function uriWithoutFilters(): void
+    {
+        $uri = new AddressListUri();
+        $this->assertEquals('adressen', $uri->getUri());
+    }
+
+    /**
+     * URI with only filters.
+     *
+     * @test
+     */
+    public function uriWithFilters(): void
+    {
+        $uri = AddressListUri::fromFilters(
+            $this->createFiltersMock()
+        );
+
+        $this->assertSame(
+            'adressen?biz=fuzz&baz=123',
+            $uri->getUri()
+        );
+    }
+
+    /**
+     * Empty filter values need to be in the query.
+     *
+     * The empty value filters need to be in the query.
+     *
+     * @test
+     */
+    public function uriContainsKeysWithEmptyValues(): void
+    {
+        $filters = $this->prophesize(FiltersInterface::class);
+        $filters
+            ->filters()
+            ->willReturn(
+                [
+                    'biz' => '',
+                    'baz' => '',
+                ]
+            );
+
+        $uri = AddressListUri::fromFilters($filters->reveal());
+
+        $this->assertSame(
+            'adressen?biz=&baz=',
+            $uri->getUri()
+        );
+    }
+
+    /**
+     * URI with only pager.
+     *
+     * @test
+     */
+    public function uriWithPager(): void
+    {
+        $uri = AddressListUri::fromPager(
+            $this->createPagerMock()
+        );
+
+        $this->assertSame(
+            'adressen?offset=250&limit=50',
+            $uri->getUri()
+        );
+    }
+
+    /**
+     * URI with filters and pager.
+     *
+     * @test
+     */
+    public function uriWithFiltersAndPager(): void
+    {
+        $uri = AddressListUri::fromFiltersAndPager(
+            $this->createFiltersMock(),
+            $this->createPagerMock()
+        );
+
+        $this->assertSame(
+            'adressen?biz=fuzz&baz=123&offset=250&limit=50',
+            $uri->getUri()
+        );
+    }
+
+    /**
+     * Create filters mock.
+     *
+     * @return \DigipolisGent\Flanders\BasicRegisters\Filter\FiltersInterface
+     */
+    private function createFiltersMock(): FiltersInterface
+    {
+        $filters = $this->prophesize(FiltersInterface::class);
+        $filters
+            ->filters()
+            ->willReturn(
+                [
+                    'biz' => 'fuzz',
+                    'baz' => 123,
+                ]
+            );
+
+        return $filters->reveal();
+    }
+
+    /**
+     * Create a pager mock.
+     *
+     * @return \DigipolisGent\Flanders\BasicRegisters\Pager\PagerInterface
+     */
+    private function createPagerMock(): PagerInterface
+    {
+        $pager = $this->prophesize(PagerInterface::class);
+        $pager
+            ->query()
+            ->willReturn(
+                [
+                    'offset' => 250,
+                    'limit' => 50,
+                ]
+            );
+
+        return $pager->reveal();
+    }
+}

--- a/tests/Uri/AddressListUriTest.php
+++ b/tests/Uri/AddressListUriTest.php
@@ -4,19 +4,16 @@ declare(strict_types=1);
 
 namespace DigipolisGent\Tests\Flanders\BasicRegisters\Uri;
 
-use DigipolisGent\Flanders\BasicRegisters\Filter\FiltersInterface;
-use DigipolisGent\Flanders\BasicRegisters\Pager\PagerInterface;
 use DigipolisGent\Flanders\BasicRegisters\Uri\AddressListUri;
 use PHPStan\Testing\TestCase;
 
 /**
- * @covers \DigipolisGent\Flanders\BasicRegisters\Uri\AbstractUriWithQuery
  * @covers \DigipolisGent\Flanders\BasicRegisters\Uri\AddressListUri
  */
 class AddressListUriTest extends TestCase
 {
     /**
-     * URI without filters.
+     * Basic path.
      *
      * @test
      */
@@ -24,97 +21,5 @@ class AddressListUriTest extends TestCase
     {
         $uri = new AddressListUri();
         $this->assertEquals('adressen', $uri->getUri());
-    }
-
-    /**
-     * URI with only filters.
-     *
-     * @test
-     */
-    public function uriWithFilters(): void
-    {
-        $uri = AddressListUri::fromFilters(
-            $this->createFiltersMock()
-        );
-
-        $this->assertSame(
-            'adressen?biz=fuzz&baz=123',
-            $uri->getUri()
-        );
-    }
-
-    /**
-     * URI with only pager.
-     *
-     * @test
-     */
-    public function uriWithPager(): void
-    {
-        $uri = AddressListUri::fromPager(
-            $this->createPagerMock()
-        );
-
-        $this->assertSame(
-            'adressen?offset=250&limit=50',
-            $uri->getUri()
-        );
-    }
-
-    /**
-     * URI with filters and pager.
-     *
-     * @test
-     */
-    public function uriWithFiltersAndPager(): void
-    {
-        $uri = AddressListUri::fromFiltersAndPager(
-            $this->createFiltersMock(),
-            $this->createPagerMock()
-        );
-
-        $this->assertSame(
-            'adressen?biz=fuzz&baz=123&offset=250&limit=50',
-            $uri->getUri()
-        );
-    }
-
-    /**
-     * Create filters mock.
-     *
-     * @return \DigipolisGent\Flanders\BasicRegisters\Filter\FiltersInterface
-     */
-    private function createFiltersMock(): FiltersInterface
-    {
-        $filters = $this->prophesize(FiltersInterface::class);
-        $filters
-            ->filters()
-            ->willReturn(
-                [
-                    'biz' => 'fuzz',
-                    'baz' => 123,
-                ]
-            );
-
-        return $filters->reveal();
-    }
-
-    /**
-     * Create a pager mock.
-     *
-     * @return \DigipolisGent\Flanders\BasicRegisters\Pager\PagerInterface
-     */
-    private function createPagerMock(): PagerInterface
-    {
-        $pager = $this->prophesize(PagerInterface::class);
-        $pager
-            ->query()
-            ->willReturn(
-                [
-                    'offset' => 250,
-                    'limit' => 50,
-                ]
-            );
-
-        return $pager->reveal();
     }
 }


### PR DESCRIPTION
When a filter was added with a NULL value, then the filter key was not
added to the query string. This is now fixed.

## Motivation and Context

Add option to filter where value is empty.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.
- [x] I have read the **CONTRIBUTING** document.
