### PR TITLE
HEAT-6930737: Add config for api key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All Notable changes to `digipolisgent/flanders-basicregisters` package.
 
+## [4.0.0]
+
+### Added
+
+* Added a configuration option for a basicregisters API key.
+* [BREAKING] Added the apiKey() method to the ConfigurationInterface.
+
 ## [3.0.0]
 
 ### Fixed
@@ -138,6 +145,8 @@ Covered:
 * Added service method to get the list of post info values.
 * Added service method to get the details of a single post info value.
 
+[4.0.0]: https://github.com/district09/php_package_dg-flanders-basicregisters/compare/3.0.0...4.0.0
+[3.0.0]: https://github.com/district09/php_package_dg-flanders-basicregisters/compare/2.0.0...3.0.0
 [2.0.0]: https://github.com/district09/php_package_dg-flanders-basicregisters/compare/1.0.0...2.0.0
 [1.0.0]: https://github.com/district09/php_package_dg-flanders-basicregisters/compare/0.2.3...1.0.0
 [0.2.3]: https://github.com/district09/php_package_dg-flanders-basicregisters/compare/0.2.2...0.2.3

--- a/examples/101-AddressList.php
+++ b/examples/101-AddressList.php
@@ -5,6 +5,7 @@
  *
  * @var string $apiEndpoint
  * @var string $apiUserKey
+ * @var string $apiKey
  * @var \Symfony\Component\Console\Output\ConsoleOutput $output
  */
 
@@ -18,7 +19,7 @@ require_once __DIR__ . '/bootstrap.php';
 printTitle('Get a list of the first 20 addresses from the service.');
 
 printStep('Create the API client configuration.');
-$configuration = new Configuration($apiEndpoint, $apiUserKey);
+$configuration = new Configuration($apiEndpoint, $apiUserKey, $apiKey);
 
 printStep('Create the Guzzle client.');
 $guzzleClient = new GuzzleHttp\Client(['base_uri' => $configuration->getUri()]);

--- a/examples/102-AddressListFiltered.php
+++ b/examples/102-AddressListFiltered.php
@@ -5,6 +5,7 @@
  *
  * @var string $apiEndpoint
  * @var string $apiUserKey
+ * @var string $apiKey
  * @var \Symfony\Component\Console\Output\ConsoleOutput $output
  */
 
@@ -24,7 +25,7 @@ require_once __DIR__ . '/bootstrap.php';
 printTitle('Get a list of the addresses from the service by filter and pager.');
 
 printStep('Create the API client configuration.');
-$configuration = new Configuration($apiEndpoint, $apiUserKey);
+$configuration = new Configuration($apiEndpoint, $apiUserKey, $apiKey);
 
 printStep('Create the Guzzle client.');
 $guzzleClient = new GuzzleHttp\Client(['base_uri' => $configuration->getUri()]);

--- a/examples/111-AddressMatch.php
+++ b/examples/111-AddressMatch.php
@@ -5,6 +5,7 @@
  *
  * @var string $apiEndpoint
  * @var string $apiUserKey
+ * @var string $apiKey
  * @var \Symfony\Component\Console\Output\ConsoleOutput $output
  */
 
@@ -24,7 +25,7 @@ require_once __DIR__ . '/bootstrap.php';
 printTitle('Get a list of all addresses in Gent with belle in the street name.');
 
 printStep('Create the API client configuration.');
-$configuration = new Configuration($apiEndpoint, $apiUserKey);
+$configuration = new Configuration($apiEndpoint, $apiUserKey, $apiKey);
 
 printStep('Create the Guzzle client.');
 $guzzleClient = new GuzzleHttp\Client(['base_uri' => $configuration->getUri()]);

--- a/examples/121-AddressDetails.php
+++ b/examples/121-AddressDetails.php
@@ -5,6 +5,7 @@
  *
  * @var string $apiEndpoint
  * @var string $apiUserKey
+ * @var string $apiKey
  * @var string $exampleAddressId
  * @var \Symfony\Component\Console\Output\ConsoleOutput $output
  */
@@ -20,7 +21,7 @@ require_once __DIR__ . '/bootstrap.php';
 printTitle('Get the details of one address.');
 
 printStep('Create the API client configuration.');
-$configuration = new Configuration($apiEndpoint, $apiUserKey);
+$configuration = new Configuration($apiEndpoint, $apiUserKey, $apiKey);
 
 printStep('Create the Guzzle client.');
 $guzzleClient = new GuzzleHttp\Client(['base_uri' => $configuration->getUri()]);

--- a/examples/201-MunicipalityNameList.php
+++ b/examples/201-MunicipalityNameList.php
@@ -5,6 +5,7 @@
  *
  * @var string $apiEndpoint
  * @var string $apiUserKey
+ * @var string $apiKey
  * @var \Symfony\Component\Console\Output\ConsoleOutput $output
  */
 
@@ -19,7 +20,7 @@ require_once __DIR__ . '/bootstrap.php';
 printTitle('Get a list of the first 25 municipality names from the service.');
 
 printStep('Create the API client configuration.');
-$configuration = new Configuration($apiEndpoint, $apiUserKey);
+$configuration = new Configuration($apiEndpoint, $apiUserKey, $apiKey);
 
 printStep('Create the Guzzle client.');
 $guzzleClient = new GuzzleHttp\Client(['base_uri' => $configuration->getUri()]);

--- a/examples/211-MunicipalityNameDetail.php
+++ b/examples/211-MunicipalityNameDetail.php
@@ -5,6 +5,7 @@
  *
  * @var string $apiEndpoint
  * @var string $apiUserKey
+ * @var string $apiKey
  * @var string $exampleMunicipalityNameId
  * @var \Symfony\Component\Console\Output\ConsoleOutput $output
  */
@@ -20,7 +21,7 @@ require_once __DIR__ . '/bootstrap.php';
 printTitle('Get the details of a single municipality name from the service.');
 
 printStep('Create the API client configuration.');
-$configuration = new Configuration($apiEndpoint, $apiUserKey);
+$configuration = new Configuration($apiEndpoint, $apiUserKey, $apiKey);
 
 printStep('Create the Guzzle client.');
 $guzzleClient = new GuzzleHttp\Client(['base_uri' => $configuration->getUri()]);

--- a/examples/301-StreetNameList.php
+++ b/examples/301-StreetNameList.php
@@ -5,6 +5,7 @@
  *
  * @var string $apiEndpoint
  * @var string $apiUserKey
+ * @var string $apiKey
  * @var \Symfony\Component\Console\Output\ConsoleOutput $output
  */
 
@@ -18,7 +19,7 @@ require_once __DIR__ . '/bootstrap.php';
 printTitle('Get a list of the first 20 street names from the service.');
 
 printStep('Create the API client configuration.');
-$configuration = new Configuration($apiEndpoint, $apiUserKey);
+$configuration = new Configuration($apiEndpoint, $apiUserKey, $apiKey);
 
 printStep('Create the Guzzle client.');
 $guzzleClient = new GuzzleHttp\Client(['base_uri' => $configuration->getUri()]);

--- a/examples/302-StreetNameListFiltered.php
+++ b/examples/302-StreetNameListFiltered.php
@@ -5,6 +5,7 @@
  *
  * @var string $apiEndpoint
  * @var string $apiUserKey
+ * @var string $apiKey
  * @var \Symfony\Component\Console\Output\ConsoleOutput $output
  */
 
@@ -21,7 +22,7 @@ require_once __DIR__ . '/bootstrap.php';
 printTitle('Get a list of the first 25 street names filtered by their municipality name.');
 
 printStep('Create the API client configuration.');
-$configuration = new Configuration($apiEndpoint, $apiUserKey);
+$configuration = new Configuration($apiEndpoint, $apiUserKey, $apiKey);
 
 printStep('Create the Guzzle client.');
 $guzzleClient = new GuzzleHttp\Client(['base_uri' => $configuration->getUri()]);

--- a/examples/311-StreetNameDetail.php
+++ b/examples/311-StreetNameDetail.php
@@ -5,6 +5,7 @@
  *
  * @var string $apiEndpoint
  * @var string $apiUserKey
+ * @var string $apiKey
  * @var string $exampleStreetNameId
  * @var \Symfony\Component\Console\Output\ConsoleOutput $output
  */
@@ -20,7 +21,7 @@ require_once __DIR__ . '/bootstrap.php';
 printTitle('Get the details of a single municipality name from the service.');
 
 printStep('Create the API client configuration.');
-$configuration = new Configuration($apiEndpoint, $apiUserKey);
+$configuration = new Configuration($apiEndpoint, $apiUserKey, $apiKey);
 
 printStep('Create the Guzzle client.');
 $guzzleClient = new GuzzleHttp\Client(['base_uri' => $configuration->getUri()]);

--- a/examples/401-PostInfoList.php
+++ b/examples/401-PostInfoList.php
@@ -5,6 +5,7 @@
  *
  * @var string $apiEndpoint
  * @var string $apiUserKey
+ * @var string $apiKey
  * @var string $examplePostInfoName
  * @var \Symfony\Component\Console\Output\ConsoleOutput $output
  */
@@ -20,7 +21,7 @@ require_once __DIR__ . '/bootstrap.php';
 printTitle('Get the first 25 post info items from the service.');
 
 printStep('Create the API client configuration.');
-$configuration = new Configuration($apiEndpoint, $apiUserKey);
+$configuration = new Configuration($apiEndpoint, $apiUserKey, $apiKey);
 
 printStep('Create the Guzzle client.');
 $guzzleClient = new GuzzleHttp\Client(['base_uri' => $configuration->getUri()]);

--- a/examples/402-PostInfoListFiltered.php
+++ b/examples/402-PostInfoListFiltered.php
@@ -5,6 +5,7 @@
  *
  * @var string $apiEndpoint
  * @var string $apiUserKey
+ * @var string $apiKey
  * @var string $examplePostInfoName
  * @var string $examplePostInfoName
  * @var \Symfony\Component\Console\Output\ConsoleOutput $output
@@ -23,7 +24,7 @@ require_once __DIR__ . '/bootstrap.php';
 printTitle('Get a list of the post info items filtered by a municipality name.');
 
 printStep('Create the API client configuration.');
-$configuration = new Configuration($apiEndpoint, $apiUserKey);
+$configuration = new Configuration($apiEndpoint, $apiUserKey, $apiKey);
 
 printStep('Create the Guzzle client.');
 $guzzleClient = new GuzzleHttp\Client(['base_uri' => $configuration->getUri()]);

--- a/examples/411-PostInfoDetail.php
+++ b/examples/411-PostInfoDetail.php
@@ -5,6 +5,7 @@
  *
  * @var string $apiEndpoint
  * @var string $apiUserKey
+ * @var string $apiKey
  * @var string $examplePostInfoId
  * @var string $examplePostInfoId
  * @var \Symfony\Component\Console\Output\ConsoleOutput $output
@@ -21,7 +22,7 @@ require_once __DIR__ . '/bootstrap.php';
 printTitle('Get the details of a single post info from the service.');
 
 printStep('Create the API client configuration.');
-$configuration = new Configuration($apiEndpoint, $apiUserKey);
+$configuration = new Configuration($apiEndpoint, $apiUserKey, $apiKey);
 
 printStep('Create the Guzzle client.');
 $guzzleClient = new GuzzleHttp\Client(['base_uri' => $configuration->getUri()]);

--- a/examples/config.example.php
+++ b/examples/config.example.php
@@ -10,6 +10,9 @@ $apiEndpoint = 'https://basisregisters.vlaanderen.be/api/v1';
 // Optional api endpoint user key.
 $apiUserKey = null;
 
+// Optional basic registers api key.
+$apiKey = null;
+
 /**
  * Data used in the examples.
  */

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,3 @@
+parameters:
+    scanDirectories:
+        - %currentWorkingDirectory%/examples

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -7,7 +7,7 @@ namespace DigipolisGent\Flanders\BasicRegisters\Client;
 use DigipolisGent\API\Client\AbstractClient;
 use DigipolisGent\API\Client\Response\ResponseInterface;
 use DigipolisGent\API\Logger\RequestLog;
-use GuzzleHttp\Exception\ClientException;
+use DigipolisGent\Flanders\BasicRegisters\Configuration\ConfigurationInterface;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -16,7 +16,7 @@ use Psr\Http\Message\RequestInterface;
 final class Client extends AbstractClient
 {
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      *
      * We do want the exceptions being throwed by Guzzle bubble up.
      */
@@ -33,9 +33,9 @@ final class Client extends AbstractClient
     }
 
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      *
-     * This will add the user key if a value is set.
+     * This will add the user key and/or api key if a value is set.
      */
     protected function injectHeaders(RequestInterface $request): RequestInterface
     {
@@ -45,6 +45,10 @@ final class Client extends AbstractClient
         $userKey = $configuration->userKey();
         if (!empty($userKey)) {
             $request = $request->withHeader('user-key', $userKey);
+        }
+        $apiKey = $configuration->apiKey();
+        if (!empty($apiKey)) {
+            $request = $request->withHeader('x-api-key', $apiKey);
         }
 
         return $request;

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -7,7 +7,6 @@ namespace DigipolisGent\Flanders\BasicRegisters\Client;
 use DigipolisGent\API\Client\AbstractClient;
 use DigipolisGent\API\Client\Response\ResponseInterface;
 use DigipolisGent\API\Logger\RequestLog;
-use DigipolisGent\Flanders\BasicRegisters\Configuration\ConfigurationInterface;
 use Psr\Http\Message\RequestInterface;
 
 /**

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -12,27 +12,30 @@ use DigipolisGent\API\Client\Configuration\Configuration as BaseConfiguration;
 final class Configuration extends BaseConfiguration implements ConfigurationInterface
 {
     /**
-     * The API user key.
-     *
-     * @var string|null
-     */
-    private $userKey;
-
-    /**
      * @inheritDoc
      */
-    public function __construct(string $endpointUri, ?string $userKey, array $options = [])
-    {
+    public function __construct(
+        protected string $endpointUri,
+        private readonly ?string $userKey = null,
+        private readonly ?string $apiKey = null,
+        array $options = []
+    ) {
         parent::__construct($endpointUri, $options);
-
-        $this->userKey = $userKey;
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function userKey(): ?string
     {
         return $this->userKey;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function apiKey(): ?string
+    {
+        return $this->apiKey;
     }
 }

--- a/src/Configuration/ConfigurationInterface.php
+++ b/src/Configuration/ConfigurationInterface.php
@@ -12,9 +12,18 @@ use DigipolisGent\API\Client\Configuration\ConfigurationInterface as BaseConfigu
 interface ConfigurationInterface extends BaseConfigurationInterface
 {
     /**
-     * Get the API user key (if any).
+     * Get the API user key for the api gateway (if any).
      *
      * @return string|null
      */
     public function userKey(): ?string;
+
+    /**
+     * Get the API key for the basic registers Flanders.
+     *
+     * @see https://basisregisters.vlaanderen.be/apikey
+     *
+     * @return string|null
+     */
+    public function apiKey(): ?string;
 }

--- a/tests/Client/ClientTest.php
+++ b/tests/Client/ClientTest.php
@@ -30,6 +30,7 @@ class ClientTest extends TestCase
 
         $configuration = $this->prophesize(ConfigurationInterface::class);
         $configuration->userKey()->willReturn($key);
+        $configuration->apiKey()->willReturn(null);
 
         $finalRequestMock = $this->prophesize(RequestInterface::class);
         $finalRequestMock
@@ -65,7 +66,7 @@ class ClientTest extends TestCase
     }
 
     /**
-     * API Key is send as header.
+     * API user Key is send as header.
      *
      * @test
      */
@@ -75,12 +76,108 @@ class ClientTest extends TestCase
 
         $configuration = $this->prophesize(ConfigurationInterface::class);
         $configuration->userKey()->willReturn($key);
+        $configuration->apiKey()->willReturn(null);
 
         $finalRequest = $this->prophesize(RequestInterface::class)->reveal();
 
         $requestWithContentLengthMock = $this->prophesize(RequestInterface::class);
         $requestWithContentLengthMock
             ->withHeader('user-key', $key)
+            ->willReturn($finalRequest)
+            ->shouldBeCalled();
+        $requestWithContentLength = $requestWithContentLengthMock->reveal();
+
+        $initialRequestMock = $this->prophesize(RequestInterface::class);
+        $initialRequestMock
+            ->getBody()
+            ->willReturn('123');
+        $initialRequestMock
+            ->withHeader(Argument::any(), Argument::any())
+            ->willReturn($requestWithContentLength);
+        $initialRequest = $initialRequestMock->reveal();
+
+        $guzzleResponse = $this->prophesize(PsrResponse::class)->reveal();
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $guzzleClient = $this->prophesize(GuzzleClient::class);
+        $guzzleClient
+            ->send($finalRequest)
+            ->willReturn($guzzleResponse);
+
+        $handler = $this->prophesize(HandlerInterface::class);
+        $handler->handles()->willReturn([get_class($initialRequest)]);
+        $handler->toResponse($guzzleResponse)->willReturn($response);
+
+        $client = new Client($guzzleClient->reveal(), $configuration->reveal());
+        $client->addHandler($handler->reveal());
+        $client->send($initialRequest);
+    }
+
+    /**
+     * No API key is added to the header if no value within configuration.
+     *
+     * @test
+     */
+    public function noApiKeyAddedIfNoValueInConfiguration(): void
+    {
+        $key = '';
+
+        $configuration = $this->prophesize(ConfigurationInterface::class);
+        $configuration->userKey()->willReturn(null);
+        $configuration->apiKey()->willReturn($key);
+
+        $finalRequestMock = $this->prophesize(RequestInterface::class);
+        $finalRequestMock
+            ->withHeader('x-api-key', $key)
+            ->shouldNotBeCalled();
+        $finalRequest = $finalRequestMock->reveal();
+
+        $initialRequestMock = $this->prophesize(RequestInterface::class);
+        $initialRequestMock
+            ->getBody()
+            ->willReturn('123');
+        $initialRequestMock
+            ->withHeader(Argument::any(), Argument::any())
+            ->willReturn($finalRequest);
+        $initialRequest = $initialRequestMock->reveal();
+
+        $guzzleResponse = $this->prophesize(PsrResponse::class)->reveal();
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $guzzleClient = $this->prophesize(GuzzleClient::class);
+        $guzzleClient
+            ->send($finalRequest)
+            ->willReturn($guzzleResponse);
+
+        $handler = $this->prophesize(HandlerInterface::class);
+        $handler->handles()->willReturn([get_class($initialRequest)]);
+        $handler->toResponse($guzzleResponse)->willReturn($response);
+
+        $client = new Client($guzzleClient->reveal(), $configuration->reveal());
+        $client->addHandler($handler->reveal());
+        $client->send($initialRequest);
+    }
+
+    /**
+     * API Key is send as header.
+     *
+     * @test
+     */
+    public function apiKeyIsSendAsHeader()
+    {
+        $key = 'fiz-baz-key';
+
+        $configuration = $this->prophesize(ConfigurationInterface::class);
+        $configuration->userKey()->willReturn(null);
+        $configuration->apiKey()->willReturn($key);
+
+        $finalRequest = $this->prophesize(RequestInterface::class)->reveal();
+
+        $requestWithContentLengthMock = $this->prophesize(RequestInterface::class);
+        $requestWithContentLengthMock
+            ->withHeader('x-api-key', $key)
             ->willReturn($finalRequest)
             ->shouldBeCalled();
         $requestWithContentLength = $requestWithContentLengthMock->reveal();


### PR DESCRIPTION
Flanders basic registers allows users to request an API key, for when
they hit a rate limit.
See https://basisregisters.vlaanderen.be/apikey

In this commit we add the ability to specify an api key that will be
passed to the x-api-key header, as required.

This will be a new major release, since we had to define a new method on
the ConfigurationInterface.